### PR TITLE
Update h5ai to version 0.29.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ RUN apt-get -q update                   \
 # Software versions
 ENV RUTORRENT_COMMIT=ac2db1536302bdc5b27aff6b15d54b0e9837fa59  \
     RUTORRENT_VERSION=3.7                                      \
-    H5AI_VERSION=0.27.0
+    H5AI_VERSION=0.29.0
 
 
 #
@@ -77,7 +77,7 @@ COPY ./overlay/var/www/rutorrent/plugins/screenshots/conf.php /var/www/rutorrent
 
 # Install h5ai
 
-RUN curl -L http://release.larsjung.de/h5ai/h5ai-$H5AI_VERSION.zip -o /tmp/h5ai.zip \
+RUN curl -L https://release.larsjung.de/h5ai/h5ai-$H5AI_VERSION.zip -o /tmp/h5ai.zip \
   && unzip /tmp/h5ai.zip -d /var/www/ \
   && rm -f /tmp/h5ai.zip \
   && ln -s /home/rtorrent/downloads /var/www/

--- a/overlay/etc/nginx/sites-available/rutorrent
+++ b/overlay/etc/nginx/sites-available/rutorrent
@@ -38,7 +38,7 @@ server {
     # Use h5ai to have a pretty listing. /var/www/downloads is a symbolic link
     # to rtorrent download directory.
     location /downloads {
-        index  /_h5ai/server/php/index.php;
+        index  /_h5ai/public/index.php;
     }
 
     # Public folder without authentication


### PR DESCRIPTION
Last version of h5ai available is v0.29.0 (actual image use v0.27.0)
- See last version available on : https://larsjung.de/h5ai/
- Changelog : https://github.com/lrsjng/h5ai/blob/master/CHANGELOG.md